### PR TITLE
Fix remaining maven-releases references in deployment URLs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -263,7 +263,7 @@ pipeline {
                         -Dversion=${SEMANTIC_VERSION} \
                         -Dpackaging=jar \
                         -DrepositoryId=nexus-all \
-                        -Durl=http://host.docker.internal:8096/repository/maven-releases/ \
+                        -Durl=http://host.docker.internal:8096/repository/maven-artifacts-${params.ENVIRONMENT}/ \
                         -s custom-settings.xml
 
                     echo "✅ Published ${LIBRARY_NAME}:${SEMANTIC_VERSION} to Nexus"
@@ -276,7 +276,7 @@ pipeline {
                         -Dversion=LATEST \
                         -Dpackaging=jar \
                         -DrepositoryId=nexus-all \
-                        -Durl=http://host.docker.internal:8096/repository/maven-releases/ \
+                        -Durl=http://host.docker.internal:8096/repository/maven-artifacts-${params.ENVIRONMENT}/ \
                         -s custom-settings.xml
 
                     echo "✅ Published ${LIBRARY_NAME}:LATEST alias to Nexus"


### PR DESCRIPTION
- Replace all maven-releases URLs with maven-artifacts-${params.ENVIRONMENT}
- Ensure consistent environment-aware repository usage
- Fix build failure caused by mixed repository configurations

🤖 Generated with [Claude Code](https://claude.ai/code)