### PR TITLE
Fix circular reference in environment variable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
 
     parameters {
         choice(
-            name: 'ENVIRONMENT',
+            name: 'ENV',
             choices: ['dev', 'qa', 'ps', 'prod'],
             description: 'Target environment for library deployment'
         )
@@ -24,7 +24,8 @@ pipeline {
 
     environment {
         LIBRARY_NAME = "${env.JOB_NAME.replace('-pipeline', '')}"
-        ENV = "${ENV}"
+        ENV = "${params.ENV}"
+
     }
 
     stages {


### PR DESCRIPTION
- Change ENV = "${ENV}" to ENV = "${params.ENV}"
- Fix parameter reference to properly use ENV parameter
- Enable proper environment variable resolution in shell scripts

🤖 Generated with [Claude Code](https://claude.ai/code)